### PR TITLE
fix: upgrade framer-motion to motion v12 for React 19 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
-        "framer-motion": "^11.11.15",
+        "motion": "^12.34.0",
         "next": "^15.5.12",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -17,8 +17,8 @@
       },
       "devDependencies": {
         "@types/node": "^20",
-        "@types/react": "^18",
-        "@types/react-dom": "^18",
+        "@types/react": "^19.2.13",
+        "@types/react-dom": "^19.2.3",
         "eslint": "^8",
         "eslint-config-next": "15.0.3",
         "postcss": "^8",
@@ -934,26 +934,24 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.13",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.12",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
+      "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.1",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1638,7 +1636,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2475,15 +2475,19 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "11.11.15",
+      "version": "12.34.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.0.tgz",
+      "integrity": "sha512-+/H49owhzkzQyxtn7nZeF4kdH++I2FWrESQ184Zbcw5cEqNHYkE5yxWxcTLSj5lNx3NWdbIRy5FHqUvetD8FWg==",
       "license": "MIT",
       "dependencies": {
+        "motion-dom": "^12.34.0",
+        "motion-utils": "^12.29.2",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
         "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/is-prop-valid": {
@@ -3408,6 +3412,47 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.34.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.0.tgz",
+      "integrity": "sha512-01Sfa/zgsD/di8zA/uFW5Eb7/SPXoGyUfy+uMRMW5Spa8j0z/UbfQewAYvPMYFCXRlyD6e5aLHh76TxeeJD+RA==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.34.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.0.tgz",
+      "integrity": "sha512-Lql3NuEcScRDxTAO6GgUsRHBZOWI/3fnMlkMcH5NftzcN37zJta+bpbMAV9px4Nj057TuvRooMK7QrzMCgtz6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "framer-motion": "^11.11.15",
+    "motion": "^12.34.0",
     "next": "^15.5.12",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
+    "@types/react": "^19.2.13",
+    "@types/react-dom": "^19.2.3",
     "eslint": "^8",
     "eslint-config-next": "15.0.3",
     "postcss": "^8",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { motion, useScroll, useTransform } from 'framer-motion';
+import { motion, useScroll, useTransform } from 'motion/react';
 import { useRef } from 'react';
 import dynamic from 'next/dynamic';
 
@@ -15,7 +15,7 @@ const fadeUp = {
   visible: {
     opacity: 1,
     y: 0,
-    transition: { duration: 0.6, ease: [0.25, 0.4, 0.25, 1] },
+    transition: { duration: 0.6, ease: [0.25, 0.4, 0.25, 1] as [number, number, number, number] },
   },
 };
 
@@ -91,7 +91,7 @@ function Hero() {
           className="flex items-center gap-3 mb-8"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2, ease: [0.25, 0.4, 0.25, 1] }}
+          transition={{ duration: 0.6, delay: 0.2, ease: [0.25, 0.4, 0.25, 1] as [number, number, number, number] }}
         >
           <div className="w-2 h-2 rounded-full bg-accent animate-pulse" />
           <span className="text-sm font-mono text-muted">Calgary, AB</span>
@@ -101,7 +101,7 @@ function Hero() {
           className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-semibold tracking-tight leading-[1.08] mb-6"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.3, ease: [0.25, 0.4, 0.25, 1] }}
+          transition={{ duration: 0.6, delay: 0.3, ease: [0.25, 0.4, 0.25, 1] as [number, number, number, number] }}
         >
           I build software
           <br />
@@ -112,7 +112,7 @@ function Hero() {
           className="text-lg md:text-xl text-muted max-w-xl leading-relaxed mb-10"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.45, ease: [0.25, 0.4, 0.25, 1] }}
+          transition={{ duration: 0.6, delay: 0.45, ease: [0.25, 0.4, 0.25, 1] as [number, number, number, number] }}
         >
           Developer and entrepreneur. Founded{' '}
           <a
@@ -139,7 +139,7 @@ function Hero() {
           className="flex flex-wrap gap-3"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.6, ease: [0.25, 0.4, 0.25, 1] }}
+          transition={{ duration: 0.6, delay: 0.6, ease: [0.25, 0.4, 0.25, 1] as [number, number, number, number] }}
         >
           <a
             href="#work"


### PR DESCRIPTION
Fixes the deploy error from PR #3's React 19.2.4 upgrade.

**Problem:** `framer-motion@11.11.15` only supports `react@^18.0.0` as a peer dep, causing `npm ci` to fail on Dokploy.

**Fix:**
- Replaced `framer-motion` with `motion` (v12+) which supports React 19
- Updated import path from `framer-motion` → `motion/react`
- Fixed cubic bezier ease type annotations for stricter motion v12 types
- Updated `@types/react` and `@types/react-dom` to latest

Build passes locally ✅