### PR TITLE
chore: update minor/patch dependencies (2026-03-04)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
-        "motion": "^12.34.4",
+        "motion": "^12.34.5",
         "next": "^16.1.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -3376,12 +3376,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.34.4",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.4.tgz",
-      "integrity": "sha512-q1PwNhc1XJ3qYG7nc9+pEU5P3tnjB6Eh9vv5gGzy61nedDLB4+xk5peMCWhKM0Zn6sfhgunf/q9n0UgCoyKOBA==",
+      "version": "12.34.5",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.5.tgz",
+      "integrity": "sha512-Z2dQ+o7BsfpJI3+u0SQUNCrN+ajCKJen1blC4rCHx1Ta2EOHs+xKJegLT2aaD9iSMbU3OoX+WabQXkloUbZmJQ==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.34.3",
+        "motion-dom": "^12.34.5",
         "motion-utils": "^12.29.2",
         "tslib": "^2.4.0"
       },
@@ -4431,12 +4431,12 @@
       }
     },
     "node_modules/motion": {
-      "version": "12.34.4",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.4.tgz",
-      "integrity": "sha512-J0cuDNRymNzE0M2WY8CFcbQuprHBZwY+iqADKGLLe6kQUVP4kBQ2l7Z6gWK7Zfrt5Wgxs+kCojj4qu7I4wxBIw==",
+      "version": "12.34.5",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.5.tgz",
+      "integrity": "sha512-N06NLJ9IeBHeielRqIvYvjPfXuRdyTxa+9++BgpGa+hY2D7TcMkI6QzV3jaRuv0aZRXgMa7cPy9YcBUBisPzAQ==",
       "license": "MIT",
       "dependencies": {
-        "framer-motion": "^12.34.4",
+        "framer-motion": "^12.34.5",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -4457,9 +4457,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.34.3",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
-      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "version": "12.34.5",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.5.tgz",
+      "integrity": "sha512-k33CsnxO2K3gBRMUZT+vPmc4Utlb5menKdG0RyVNLtlqRaaJPRWlE9fXl8NTtfZ5z3G8TDvqSu0MENLqSTaHZA==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.29.2"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "motion": "^12.34.4",
+    "motion": "^12.34.5",
     "next": "^16.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
## Dependency Updates

### Portfolio
- `motion` 12.34.4 → 12.34.5 (patch)

### Skipped (major bumps — require manual review)
- `tailwind-merge` 2.6.1 → 3.5.0 (major)
- `tailwindcss` 3.4.19 → 4.2.1 (major — previously reverted)

✅ Build verified clean before PR.