### PR TITLE
chore: update motion 12.34.5 → 12.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
-        "motion": "^12.34.5",
+        "motion": "^12.35.0",
         "next": "^16.1.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -3376,12 +3376,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.34.5",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.5.tgz",
-      "integrity": "sha512-Z2dQ+o7BsfpJI3+u0SQUNCrN+ajCKJen1blC4rCHx1Ta2EOHs+xKJegLT2aaD9iSMbU3OoX+WabQXkloUbZmJQ==",
+      "version": "12.35.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.35.0.tgz",
+      "integrity": "sha512-w8hghCMQ4oq10j6aZh3U2yeEQv5K69O/seDI/41PK4HtgkLrcBovUNc0ayBC3UyyU7V1mrY2yLzvYdWJX9pGZQ==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.34.5",
+        "motion-dom": "^12.35.0",
         "motion-utils": "^12.29.2",
         "tslib": "^2.4.0"
       },
@@ -4431,12 +4431,12 @@
       }
     },
     "node_modules/motion": {
-      "version": "12.34.5",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.5.tgz",
-      "integrity": "sha512-N06NLJ9IeBHeielRqIvYvjPfXuRdyTxa+9++BgpGa+hY2D7TcMkI6QzV3jaRuv0aZRXgMa7cPy9YcBUBisPzAQ==",
+      "version": "12.35.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.35.0.tgz",
+      "integrity": "sha512-BQUhNUIGvUcwXCzwmnT1JpjUqab34lIwxHnXUyWRht1WC1vAyp7/4qgMiUXxN3K6hgUhyoR+HNnLeQMwUZjVjw==",
       "license": "MIT",
       "dependencies": {
-        "framer-motion": "^12.34.5",
+        "framer-motion": "^12.35.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -4457,9 +4457,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.34.5",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.5.tgz",
-      "integrity": "sha512-k33CsnxO2K3gBRMUZT+vPmc4Utlb5menKdG0RyVNLtlqRaaJPRWlE9fXl8NTtfZ5z3G8TDvqSu0MENLqSTaHZA==",
+      "version": "12.35.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.35.0.tgz",
+      "integrity": "sha512-FFMLEnIejK/zDABn+vqGVAUN4T0+3fw+cVAY8MMT65yR+j5uMuvWdd4npACWhh94OVWQs79CrBBuwOwGRZAQiA==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.29.2"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "motion": "^12.34.5",
+    "motion": "^12.35.0",
     "next": "^16.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
Minor dep bump. Build passes ✅ 0 vulnerabilities.