### PR TITLE
chore: remove unused clsx and tailwind-merge dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,10 @@
       "name": "portfolio",
       "version": "0.1.0",
       "dependencies": {
-        "clsx": "^2.1.1",
         "motion": "^12.35.0",
         "next": "^16.1.6",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "tailwind-merge": "^2.6.1"
+        "react-dom": "^19.2.4"
       },
       "devDependencies": {
         "@types/node": "^25.3.3",
@@ -2321,15 +2319,6 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -5789,16 +5778,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tailwind-merge": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
-      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,10 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "clsx": "^2.1.1",
     "motion": "^12.35.0",
     "next": "^16.1.6",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "tailwind-merge": "^2.6.1"
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
     "@types/node": "^25.3.3",


### PR DESCRIPTION
## Summary

Neither `clsx` nor `tailwind-merge` are imported anywhere in the portfolio source code. Both appear to have been installed during a Tailwind v4 migration attempt that was subsequently reverted, leaving them as dead dependencies.

## Changes
- Removed `clsx@^2.1.1` from dependencies
- Removed `tailwind-merge@^2.6.1` from dependencies
- Updated `package-lock.json`

## Verification
- Build passes: ✅ `npm run build` clean
- TypeScript: ✅ no errors
- No source files import either package (verified with grep)