### PR TITLE
chore: add .worktree-meta to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 RESUME.txt
+.worktree-meta


### PR DESCRIPTION
Preventive fix: add `.worktree-meta` to `.gitignore` so agent worktree metadata never gets accidentally committed. Learned from munden-trucking-website PR #23 (flagged by Lisa QA).