### PR TITLE
fix: lighthouse a11y - contrast ratios + accessible name

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -442,7 +442,7 @@ function Footer() {
         </div>
       </AnimatedSection>
 
-      <AnimatedSection className="mt-16 pt-8 border-t border-white/[0.06] text-xs text-muted/70 font-mono">
+      <AnimatedSection className="mt-16 pt-8 border-t border-white/[0.06] text-xs text-muted font-mono">
         © {new Date().getFullYear()} Jonah Duckworth
       </AnimatedSection>
     </footer>

--- a/src/components/AnimatedNav.tsx
+++ b/src/components/AnimatedNav.tsx
@@ -11,7 +11,7 @@ export function AnimatedNav() {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay: 0.1 }}
     >
-      <a href="#" aria-label="Home" className="text-xs sm:text-sm font-medium tracking-tight text-foreground">
+      <a href="#" className="text-xs sm:text-sm font-medium tracking-tight text-foreground">
         jonah duckworth
       </a>
       <div className="flex items-center gap-3 sm:gap-6">

--- a/src/components/AnimatedTechStrip.tsx
+++ b/src/components/AnimatedTechStrip.tsx
@@ -30,14 +30,14 @@ export function AnimatedTechStrip() {
       >
         {categories.map((cat) => (
           <div key={cat.label} className="flex flex-col sm:flex-row sm:items-center gap-3">
-            <span className="text-xs font-mono text-muted/70 uppercase tracking-widest w-20 flex-shrink-0">
+            <span className="text-xs font-mono text-muted uppercase tracking-widest w-20 flex-shrink-0">
               {cat.label}
             </span>
             <div className="flex flex-wrap gap-2">
               {cat.tools.map((tool) => (
                 <motion.span
                   key={tool}
-                  className="text-xs font-mono text-muted/65 px-3 py-1.5 rounded-full border border-white/[0.07] hover:border-white/[0.12] hover:text-muted transition-all duration-200"
+                  className="text-xs font-mono text-muted/90 px-3 py-1.5 rounded-full border border-white/[0.07] hover:border-white/[0.12] hover:text-muted transition-all duration-200"
                   variants={fadeUp}
                 >
                   {tool}


### PR DESCRIPTION
Fixes #22

## Changes
- **Contrast ratio fixes**: text-muted/70 → text-muted and text-muted/65 → text-muted/90 to pass WCAG AA (4.5:1 minimum)
- **Accessible name**: Removed mismatched aria-label=Home on nav link where visible text is jonah duckworth

## Lighthouse Scores (baseline)
| Category | Mobile | Desktop |
|----------|--------|---------|
| Performance | 95 | 100 |
| Accessibility | 96 → target 100 | 96 → target 100 |
| Best Practices | 100 | 100 |
| SEO | 100 | 100 |