### PR TITLE
feat: add clients nav redirect

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,8 +2,10 @@ import nextConfig from "eslint-config-next";
 import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 import nextTypescript from "eslint-config-next/typescript";
 
-export default [
+const eslintConfig = [
   ...nextConfig,
   ...nextCoreWebVitals,
   ...nextTypescript,
 ];
+
+export default eslintConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/clients",
+        destination: "https://clients.jdbuilds.ca",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "motion": "^12.35.0",

--- a/src/components/AnimatedNav.tsx
+++ b/src/components/AnimatedNav.tsx
@@ -12,9 +12,10 @@ export function AnimatedNav() {
       transition={{ duration: 0.5, delay: 0.1 }}
     >
       <a href="#" className="text-xs sm:text-sm font-medium tracking-tight text-foreground">
-        jonah duckworth
+        <span className="sm:hidden">jd</span>
+        <span className="hidden sm:inline">jonah duckworth</span>
       </a>
-      <div className="flex items-center gap-3 sm:gap-6">
+      <div className="flex items-center gap-2 sm:gap-6">
         <a
           href="#work"
           className="text-xs sm:text-sm text-muted hover:text-foreground transition-colors duration-200"
@@ -32,6 +33,12 @@ export function AnimatedNav() {
           className="text-xs sm:text-sm text-muted hover:text-foreground transition-colors duration-200"
         >
           speaking
+        </a>
+        <a
+          href="https://clients.jdbuilds.ca"
+          className="text-xs sm:text-sm text-muted hover:text-foreground transition-colors duration-200"
+        >
+          clients
         </a>
         <a
           href="#contact"


### PR DESCRIPTION
## What

- Adds a clients link between speaking and contact in the portfolio header.
- Points the header link to https://clients.jdbuilds.ca.
- Adds a permanent /clients redirect to the clients subdomain.
- Keeps the mobile header fitting by using a compact JD brand label on small screens.

## Testing

- npm run build
- npx eslint . (passes with existing eslint.config.mjs warning)
- Browser checked desktop and 375px mobile header layout
- curl -I http://localhost:3000/clients returns 308 to https://clients.jdbuilds.ca/